### PR TITLE
SettingsGoogle: Large LS clock fix

### DIFF
--- a/res/xml/x_settings_lockscreen.xml
+++ b/res/xml/x_settings_lockscreen.xml
@@ -55,8 +55,7 @@
             settings:min="80"
             settings:interval="1"
             android:defaultValue="200"
-            android:persistent="true"
-            settings:units="dp" />
+            android:persistent="true" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Removal of units fixes the scaling issue with large LS clock